### PR TITLE
ci: Create venv for maturin develop ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,16 @@ jobs:
       - name: test pylancelot
         working-directory: ./pylancelot/
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           pip install -U pip setuptools maturin pytest pefile
           maturin develop
           pytest
       - name: test pyflirt
         working-directory: ./pyflirt/
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           pip install -U pip setuptools maturin pytest pefile
           maturin develop
           pytest


### PR DESCRIPTION
Creates a Python virtual environment for running the ci tests using maturin develop. Perhaps doing `maturin build` and then installing the built wheel before running pytest would be cleaner, I think it would at least remove the explicit pip install command to install dependencies like pefile (installing the wheel that gets built would also install dependencies).