### PR TITLE
coff: handle Data/Text symbols with Unknown section as weak externals

### DIFF
--- a/core/src/loader/coff/mod.rs
+++ b/core/src/loader/coff/mod.rs
@@ -334,7 +334,9 @@ fn get_coff_extern_names(obj: &object::File) -> BTreeSet<String> {
                 match (symbol.kind(), symbol.section()) {
                     (
                         object::SymbolKind::Data | object::SymbolKind::Text,
-                        object::SymbolSection::Undefined | object::SymbolSection::Common,
+                        object::SymbolSection::Undefined
+                            | object::SymbolSection::Common
+                            | object::SymbolSection::Unknown,
                     ) => {
                         debug!("coff: reloc: extern: symbol: {}", name);
                         externs.insert(name.to_string());

--- a/core/src/loader/coff/mod.rs
+++ b/core/src/loader/coff/mod.rs
@@ -519,7 +519,9 @@ fn get_coff_fixups(
                 (
                     // we place these extern symbols in a fake section named "UNDEF".
                     object::SymbolKind::Data | object::SymbolKind::Text,
-                    object::SymbolSection::Undefined | object::SymbolSection::Common,
+                    object::SymbolSection::Undefined
+                        | object::SymbolSection::Common
+                        | object::SymbolSection::Unknown,
                 ) => {
                     let Ok(name) = symbol.name() else {
                         warn!("coff: reloc: no name: {:?}", symbol);


### PR DESCRIPTION
## Summary

When parsing static libraries containing C++ weak external symbols, the COFF relocation resolver panics on `Text`-kind symbols with `section: Unknown` (e.g. `__cxa_pure_virtual`). These symbols fall through to the catch-all `unimplemented!` arm.

Closes #235 

## Issue

`jh` crashes with:

```
The application panicked (crashed).
  not implemented: unsupported symbol: Symbol {
      name: "__cxa_pure_virtual",
      address: 0,
      size: 0,
      kind: Text,
      section: Unknown,
      scope: Linkage,
      weak: true,
      flags: None
  }
in core/src/loader/coff/mod.rs, line 593
```

## Fix

Two changes in `core/src/loader/coff/mod.rs`:

1. Extend the existing `Data`/`Text` + `Undefined`/`Common` relocation arm to also accept `Unknown` sections, resolving them via the externs table.
2. Extend `get_coff_extern_names` to also collect `Data`/`Text` symbols with `Unknown` sections into the externs table. Without this, the resolver would warn `failed to find extern: "__cxa_pure_virtual"` because the symbol was never assigned an entry in the UNDEF section.

## Verification

- `cargo build --release -p lancelot-bin` succeeds.
- `jh` no longer panics on the cryptopp static library reproducer, and no longer warns about missing `__cxa_pure_virtual`.
