### PR TITLE
release v0.10.0

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lancelot-bin"
-version = "0.9.10"
+version = "0.10.0"
 description = "binary analysis tools for x32/x64 PE files"
 authors = ["William Ballenthin <william.ballenthin@fireeye.com>"]
 license = "Apache-2.0"
@@ -28,6 +28,6 @@ hex = "0.4"
 serde_json = "1.0"
 sha256 = "1"
 
-lancelot = { path = "../core", version = "0.9.10" }
-lancelot-flirt = { path = "../flirt", version = "0.9.10" }
+lancelot = { path = "../core", version = "0.10.0" }
+lancelot-flirt = { path = "../flirt", version = "0.10.0" }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lancelot"
 description = "binary analysis framework for x32/x64 PE files"
 license = "Apache-2.0"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["Willi Ballenthin <william.ballenthin@mandiant.com>"]
 edition = "2021"
 homepage = "https://github.com/williballenthin/lancelot"
@@ -37,7 +37,7 @@ fern = { version = "0.7", optional = true }
 bitvec = { version = "1" }
 
 # needed for flirt
-lancelot-flirt = { path = "../flirt", version = "0.9.10", optional = true}
+lancelot-flirt = { path = "../flirt", version = "0.10.0", optional = true}
 
 # needed for binexport2
 prost = "0.13"

--- a/flirt/Cargo.toml
+++ b/flirt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lancelot-flirt"
 description = "parse and match FLIRT signatures"
 license = "Apache-2.0"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["Willi Ballenthin <william.ballenthin@mandiant.com>"]
 edition = "2021"
 homepage = "https://github.com/williballenthin/lancelot"

--- a/jslancelot/Cargo.toml
+++ b/jslancelot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jslancelot"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["Willi Ballenthin <william.ballenthin@mandiant.com>"]
 edition = "2021"
 homepage = "https://github.com/williballenthin/lancelot"
@@ -12,8 +12,8 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-lancelot = { path = "../core", version = "0.9.10" }
-lancelot-flirt = { path = "../flirt", version = "0.9.10" }
+lancelot = { path = "../core", version = "0.10.0" }
+lancelot-flirt = { path = "../flirt", version = "0.10.0" }
 anyhow = "1"
 sha2 = "0.10"
 

--- a/jslancelot/package.json
+++ b/jslancelot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jslancelot",
-  "version": "0.9.10",
+  "version": "0.10.0",
   "description": "binary analysis framework for x32/x64 PE files: analyze bytes, produce a BinExport2 protobuf. runs entirely in WebAssembly, in both Node and the browser.",
   "license": "Apache-2.0",
   "author": "Willi Ballenthin <william.ballenthin@mandiant.com>",

--- a/pyflirt/Cargo.toml
+++ b/pyflirt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-flirt"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["William Ballenthin <william.ballenthin@fireeye.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -13,7 +13,7 @@ name = "flirt"
 crate-type = ["cdylib"]
 
 [dependencies]
-lancelot-flirt = { path = "../flirt", version = "0.9.10" }
+lancelot-flirt = { path = "../flirt", version = "0.10.0" }
 pyo3 = { version = "0.27", features = ["generate-import-lib"] }
 anyhow = "1"
 

--- a/pyflirt/pyproject.toml
+++ b/pyflirt/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-flirt"
-version = "0.9.10"
+version = "0.10.0"
 description = "A Python library for parsing, compiling, and matching Fast Library Identification and Recognition Technology (FLIRT) signatures."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pylancelot/Cargo.toml
+++ b/pylancelot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylancelot"
-version = "0.9.10"
+version = "0.10.0"
 authors = ["Willi Ballenthin <william.ballenthin@mandiant.com>"]
 edition = "2021"
 homepage = "https://github.com/williballenthin/lancelot"
@@ -11,7 +11,7 @@ name = "lancelot"
 crate-type = ["cdylib"]
 
 [dependencies]
-lancelot = { path = "../core", version = "0.9.10" }
+lancelot = { path = "../core", version = "0.10.0" }
 pyo3 = { version = "0.27", features = ["generate-import-lib"] }
 pyo3-log = "0.13"
 anyhow = "1"

--- a/pylancelot/pyproject.toml
+++ b/pylancelot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-lancelot"
-version = "0.9.10"
+version = "0.10.0"
 description = "Intel x86(-64) code analysis library that reconstructs control flow"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump all crate, Python, and npm package versions from 0.9.10 to 0.10.0 via `.github/workflows/bump-version.sh`.

Proposed release notes for the v0.10.0 GitHub release:

---

adds:
- jslancelot: JavaScript bindings for npm, running the wasm build of the core library so the same package works in both Node and the browser (mirrors pylancelot's API: bytes in, BinExport2 bytes out)
- ci: build the jslancelot npm package and attach it to releases

changes:
- update zydis from 3.1.3 to 4.1.1 (#240)
- update goblin from 0.9 to 0.10, parse PEs permissively (accepts PEs with collapsed headers, like the Windows loader does)
- jh: emit JSONL instead of hand-rolled CSV (#238)

fixes:
- pe: don't stop at zero entries in the exception directory, so functions are found in incrementally linked binaries
- coff: handle relocations against undefined section symbols
- coff: handle weak external Data/Text symbols with Unknown section (#235)
- noret: don't panic on already-pruned instructions in batch processing (#236)

**Full Changelog**: https://github.com/williballenthin/lancelot/compare/v0.9.10...v0.10.0

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YTekM7xsnak4URYaPubxz

---
_Generated by [Claude Code](https://claude.ai/code/session_012YTekM7xsnak4URYaPubxz)_