### PR TITLE
bin: exit nonzero when CLI tools fail

### DIFF
--- a/bin/src/bin/be2.rs
+++ b/bin/src/bin/be2.rs
@@ -120,5 +120,6 @@ fn main() {
         error!("{:?}", e);
         #[cfg(not(debug_assertions))]
         error!("{:}", e);
+        std::process::exit(1);
     }
 }

--- a/bin/src/bin/jh.rs
+++ b/bin/src/bin/jh.rs
@@ -503,8 +503,7 @@ fn _main() -> Result<()> {
             output_functions_features(&build, &path, &features, &mut std::io::stdout())?;
         }
     } else {
-        error!("unrecognized file format");
-        return Ok(());
+        return Err(anyhow::anyhow!("unrecognized file format"));
     }
 
     Ok(())
@@ -516,6 +515,7 @@ fn main() {
         error!("{:?}", e);
         #[cfg(not(debug_assertions))]
         error!("{:}", e);
+        std::process::exit(1);
     }
 }
 

--- a/bin/src/bin/lancelot.rs
+++ b/bin/src/bin/lancelot.rs
@@ -201,5 +201,6 @@ fn main() {
         error!("{:?}", e);
         #[cfg(not(debug_assertions))]
         error!("{:}", e);
+        std::process::exit(1);
     }
 }

--- a/bin/src/bin/match_flirt.rs
+++ b/bin/src/bin/match_flirt.rs
@@ -163,5 +163,6 @@ fn main() {
         error!("{:?}", e);
         #[cfg(not(debug_assertions))]
         error!("{:}", e);
+        std::process::exit(1);
     }
 }

--- a/bin/tests/exit_codes.rs
+++ b/bin/tests/exit_codes.rs
@@ -1,0 +1,104 @@
+//! the CLI tools must exit nonzero on failure,
+//! so that scripts and pipelines can detect errors.
+//! see https://github.com/williballenthin/lancelot/issues/247
+use std::process::Command;
+
+/// path to a file that does not exist,
+/// so tools fail inside their `_main` (not during argument parsing).
+const MISSING: &str = "./tests/data/definitely-does-not-exist.exe";
+
+/// path to a small, valid PE within this repository.
+fn nop_exe() -> String {
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("..");
+    path.push("core");
+    path.push("resources");
+    path.push("test");
+    path.push("nop.exe");
+    path.to_str().unwrap().to_string()
+}
+
+fn run(bin: &str, args: &[&str]) -> std::process::Output {
+    Command::new(bin)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn {bin}: {e}"))
+}
+
+fn assert_failure(bin: &str, args: &[&str]) {
+    let output = run(bin, args);
+    assert!(
+        !output.status.success(),
+        "expected nonzero exit: {bin} {args:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_success(bin: &str, args: &[&str]) {
+    let output = run(bin, args);
+    assert!(
+        output.status.success(),
+        "expected zero exit: {bin} {args:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn lancelot_missing_input() {
+    assert_failure(env!("CARGO_BIN_EXE_lancelot"), &["functions", MISSING]);
+}
+
+#[test]
+fn lancelot_no_subcommand() {
+    assert_failure(env!("CARGO_BIN_EXE_lancelot"), &[]);
+}
+
+#[test]
+fn lancelot_ok() {
+    assert_success(env!("CARGO_BIN_EXE_lancelot"), &["-q", "functions", &nop_exe()]);
+}
+
+#[test]
+fn be2_missing_input() {
+    assert_failure(env!("CARGO_BIN_EXE_be2"), &[MISSING]);
+}
+
+#[test]
+fn be2_ok() {
+    let output = run(env!("CARGO_BIN_EXE_be2"), &["-q", &nop_exe()]);
+    assert!(output.status.success());
+    // a successful run writes the BinExport2 document to stdout.
+    assert!(!output.stdout.is_empty());
+}
+
+#[test]
+fn jh_missing_input() {
+    assert_failure(
+        env!("CARGO_BIN_EXE_jh"),
+        &["i686-pc-windows-msvc", "msvc", "libtest", "1.0", "release", MISSING],
+    );
+}
+
+#[test]
+fn jh_unrecognized_format() {
+    // a file that exists but is neither PE, COFF, nor archive.
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    assert_failure(
+        env!("CARGO_BIN_EXE_jh"),
+        &[
+            "i686-pc-windows-msvc",
+            "msvc",
+            "libtest",
+            "1.0",
+            "release",
+            path.to_str().unwrap(),
+        ],
+    );
+}
+
+#[test]
+fn match_flirt_missing_input() {
+    assert_failure(env!("CARGO_BIN_EXE_match_flirt"), &[MISSING, "sigs.sig"]);
+}


### PR DESCRIPTION
Fixes #247.

All four CLI tools (`lancelot`, `be2`, `jh`, `match_flirt`) shared the same `main` shape: log the error from `_main`, then return — exiting with status 0 on failure. `be2` was the worst case: a failed run writes nothing to stdout but still "succeeds", so `be2 sample.exe > out.BinExport` silently produces an empty file. Each `main` now calls `std::process::exit(1)` after logging.

Also, `jh` treated an unrecognized input format as `error!(...)` + `Ok(())`; it now returns an error so that case reaches the nonzero exit path too (skipping unparseable *archive members* is unchanged — that stays a warning).

Testing: new `bin/tests/exit_codes.rs` integration tests spawn the real binaries via `CARGO_BIN_EXE_*` and assert exit status — no mocks:
- missing input file → nonzero, for all four tools
- `lancelot` with no subcommand → nonzero
- `jh` on an existing-but-unrecognized file → nonzero
- positive controls: `lancelot functions` and `be2` on `core/resources/test/nop.exe` → zero exit, and `be2` writes a non-empty BinExport2 to stdout

Verified the failure-path tests fail against the previous code (6 failed) and all 8 pass with the fix. `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2

---
_Generated by [Claude Code](https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2)_