### PR TITLE
noret: detect no-return functions from CFG shape

### DIFF
--- a/core/src/analysis/cfg/noret.rs
+++ b/core/src/analysis/cfg/noret.rs
@@ -95,6 +95,132 @@ pub fn cfg_prune_noret_by_name(module: &Module, cfg: &mut CFG, names: &BTreeMap<
     Ok(noret)
 }
 
+/// does the given function provably never return,
+/// judging by the shape of its CFG alone?
+///
+/// this is conservative:
+///
+///   - any reachable block ending in RET means the function returns.
+///   - any reachable block ending in an unresolved flow means we don't know, so
+///     we assume the function returns. unresolved flows are indirect
+///     unconditional jumps (possible tail call through the import table, or an
+///     unrecovered switch table) and direct edges to addresses that are not
+///     part of the CFG.
+///
+/// only when every reachable path ends in a dead end (an INT3, a call whose
+/// fallthrough was already pruned as noret, an infinite loop, ...) do we
+/// conclude the function never returns.
+fn is_provably_noret(module: &Module, cfg: &CFG, decoder: &zydis::Decoder, va: VA) -> bool {
+    if !cfg.basic_blocks.blocks_by_address.contains_key(&va) {
+        // not a basic block, e.g. not analyzed as code.
+        return false;
+    }
+
+    let mut reader: cfg::CachingPageReader = Default::default();
+
+    for block in cfg.get_reaches_from(va) {
+        let last = block.address_of_last_insn;
+        let succs = &cfg.flows.flows_by_src[&last];
+
+        if succs
+            .iter()
+            .any(|f| matches!(f, Flow::UnconditionalJump(Target::Indirect(_))))
+        {
+            // unresolved flow: a tail call through the import table or a
+            // register, or an unrecovered switch table. we can't see where
+            // this goes, so conservatively assume it returns.
+            return false;
+        }
+
+        if cfg::edge_targets(cfg::direct_edges(cfg::edges(succs)))
+            .any(|target| !cfg.basic_blocks.blocks_by_address.contains_key(&target))
+        {
+            // flow to an address that isn't part of the CFG,
+            // so the analysis here is incomplete.
+            // conservatively assume the function returns.
+            return false;
+        }
+
+        if cfg::empty(cfg::edges(succs)) {
+            // leaf block: no edges out of the final instruction.
+            // only trust instructions we positively know to be dead ends;
+            // everything else is unknown, so assume the function returns.
+            match cfg::read_insn_with_cache(&mut reader, &module.address_space, last, decoder) {
+                Ok(Some(insn)) => match insn.mnemonic {
+                    // the function returns.
+                    zydis::Mnemonic::RET | zydis::Mnemonic::IRET | zydis::Mnemonic::IRETD | zydis::Mnemonic::IRETQ => {
+                        return false;
+                    }
+
+                    // dead ends:
+                    // INT3/INT 0x29/INT 0x2C don't flow onwards
+                    // (see does_insn_fallthrough), and a CALL with no
+                    // remaining flows had its fallthrough pruned as noret.
+                    zydis::Mnemonic::INT3 | zydis::Mnemonic::INT | zydis::Mnemonic::CALL => {}
+
+                    // anything else is unknown. notably, this includes
+                    // unresolved jumps that produce no flows at all, like
+                    // an unrecovered switch `jmp [table + reg*4]` (e.g.
+                    // the dispatch inside msvc's memcpy): we can't see
+                    // where they go, so assume the function returns.
+                    _ => {
+                        return false;
+                    }
+                },
+                _ => {
+                    // can't decode the final instruction: unknown,
+                    // so conservatively assume the function returns.
+                    return false;
+                }
+            }
+        }
+    }
+
+    // every reachable path is a dead end: this function never returns.
+    true
+}
+
+/// find functions that provably never return, judging by CFG shape (see
+/// [`is_provably_noret`]), and prune the fallthrough flows after calls to
+/// them.
+///
+/// this catches no-return functions that aren't recognized by name (see
+/// [`cfg_prune_noret_by_name`]), such as in stripped or statically-linked
+/// binaries: infinite loops, INT3-terminated fatal handlers, and wrappers
+/// around already-pruned no-return calls.
+///
+/// iterates to a fixpoint: pruning one function's callers can turn a caller
+/// into a provably no-return function itself.
+///
+/// returns the set of addresses recognized as noret.
+pub fn cfg_prune_noret_functions(module: &Module, cfg: &mut CFG, functions: &BTreeSet<VA>) -> Result<BTreeSet<VA>> {
+    let decoder = dis::get_disassembler(module)?;
+    let mut noret: BTreeSet<VA> = Default::default();
+
+    loop {
+        let mut changed = false;
+
+        for &function in functions.iter() {
+            if noret.contains(&function) {
+                continue;
+            }
+
+            if is_provably_noret(module, cfg, &decoder, function) {
+                log::info!("noret via cfg: {:#x}", function);
+                noret.insert(function);
+                noret.extend(cfg_mark_noret(module, cfg, function)?);
+                changed = true;
+            }
+        }
+
+        if !changed {
+            break;
+        }
+    }
+
+    Ok(noret)
+}
+
 // With the given function address,
 // either as the target of a direct or indirect call,
 // consider it to be non-returning (such as ExitProcess).
@@ -289,6 +415,134 @@ mod tests {
         assert!(cfg.insns.insns_by_address.contains_key(&0x0));
         assert!(cfg.insns.insns_by_address.contains_key(&0x6).not());
         assert!(cfg.insns.insns_by_address.contains_key(&0x7).not());
+
+        Ok(())
+    }
+
+    #[test]
+    fn noret_by_cfg_infinite_loop() -> Result<()> {
+        // B (0xB) is an infinite loop, so it provably never returns,
+        // even though it has no name. the pass must prune the bytes after
+        // A's call to B, and then A itself becomes provably no-return
+        // (its only path now ends at the pruned call): the fixpoint.
+        //
+        // A:
+        // 0x0: E8 06 00 00 00    call 0xB
+        // 0x5: 90                nop      (dead: must be pruned)
+        // 0x6: C3                ret      (dead: must be pruned)
+        // 0x7: CC CC CC CC       padding
+        // B:
+        // 0xB: EB FE             jmp $
+        let module = load_shellcode32(b"\xE8\x06\x00\x00\x00\x90\xC3\xCC\xCC\xCC\xCC\xEB\xFE");
+        let mut insns: InstructionIndex = Default::default();
+        insns.build_index(&module, 0x0)?;
+        let mut cfg = CFG::from_instructions(&module, insns)?;
+
+        assert!(cfg.insns.insns_by_address.contains_key(&0x5));
+
+        let functions: BTreeSet<VA> = [0x0, 0xB].into_iter().collect();
+        let noret = cfg_prune_noret_functions(&module, &mut cfg, &functions)?;
+
+        assert!(noret.contains(&0xB));
+        assert!(noret.contains(&0x0));
+        assert!(cfg.insns.insns_by_address.contains_key(&0x0));
+        assert!(cfg.insns.insns_by_address.contains_key(&0x5).not());
+        assert!(cfg.insns.insns_by_address.contains_key(&0x6).not());
+
+        Ok(())
+    }
+
+    #[test]
+    fn noret_by_cfg_returning_functions_untouched() -> Result<()> {
+        // C calls D, and D plainly returns: nothing may be marked or pruned.
+        //
+        // C:
+        // 0x0: E8 06 00 00 00    call 0xB
+        // 0x5: 90                nop
+        // 0x6: C3                ret
+        // 0x7: CC CC CC CC       padding
+        // D:
+        // 0xB: C3                ret
+        let module = load_shellcode32(b"\xE8\x06\x00\x00\x00\x90\xC3\xCC\xCC\xCC\xCC\xC3");
+        let mut insns: InstructionIndex = Default::default();
+        insns.build_index(&module, 0x0)?;
+        let mut cfg = CFG::from_instructions(&module, insns)?;
+
+        let functions: BTreeSet<VA> = [0x0, 0xB].into_iter().collect();
+        let noret = cfg_prune_noret_functions(&module, &mut cfg, &functions)?;
+
+        assert!(noret.is_empty());
+        assert!(cfg.insns.insns_by_address.contains_key(&0x5));
+        assert!(cfg.insns.insns_by_address.contains_key(&0x6));
+
+        Ok(())
+    }
+
+    #[test]
+    fn noret_by_cfg_indirect_jump_is_conservative() -> Result<()> {
+        // E ends with an indirect jump (like a thunk to an import, or an
+        // unrecovered switch table): we can't see where it goes, so it must
+        // NOT be considered no-return, and F's post-call bytes must survive.
+        //
+        // F:
+        // 0x0:  E8 0B 00 00 00     call 0x10
+        // 0x5:  90                 nop      (must survive)
+        // 0x6:  C3                 ret      (must survive)
+        // 0x7:  CC x9              padding
+        // E:
+        // 0x10: FF 25 18 00 00 00  jmp [0x18]
+        // 0x16: CC CC              padding
+        // 0x18: 44 33 22 11        (pointer data)
+        let module = load_shellcode32(
+            b"\xE8\x0B\x00\x00\x00\x90\xC3\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xFF\x25\x18\x00\x00\x00\xCC\xCC\x44\x33\x22\x11",
+        );
+        let mut insns: InstructionIndex = Default::default();
+        insns.build_index(&module, 0x0)?;
+        let mut cfg = CFG::from_instructions(&module, insns)?;
+
+        let functions: BTreeSet<VA> = [0x0, 0x10].into_iter().collect();
+        let noret = cfg_prune_noret_functions(&module, &mut cfg, &functions)?;
+
+        assert!(noret.is_empty());
+        assert!(cfg.insns.insns_by_address.contains_key(&0x5));
+        assert!(cfg.insns.insns_by_address.contains_key(&0x6));
+
+        Ok(())
+    }
+
+    #[test]
+    fn noret_by_cfg_switch_dispatch_is_conservative() -> Result<()> {
+        // regression test: a scaled-index indirect jump (an unrecovered
+        // switch table, like the dispatch inside msvc's memcpy) produces NO
+        // flows at all, so its block looks like a dead-end leaf. it must not
+        // be considered no-return: the function jumps somewhere we can't see,
+        // and (in memcpy's case) very much returns.
+        //
+        // F:
+        // 0x0:  E8 0B 00 00 00        call 0x10
+        // 0x5:  90                    nop   (must survive)
+        // 0x6:  C3                    ret   (must survive)
+        // 0x7:  CC x9                 padding
+        // S:
+        // 0x10: FF 24 85 18 00 00 00  jmp [eax*4+0x18]
+        // 0x17: CC                    padding
+        // 0x18: 44 33 22 11           (table data)
+        let module = load_shellcode32(
+            b"\xE8\x0B\x00\x00\x00\x90\xC3\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xCC\xFF\x24\x85\x18\x00\x00\x00\xCC\x44\x33\x22\x11",
+        );
+        let mut insns: InstructionIndex = Default::default();
+        insns.build_index(&module, 0x0)?;
+        let mut cfg = CFG::from_instructions(&module, insns)?;
+
+        // the switch dispatch produced no flows: it's a leaf ending in JMP.
+        assert!(cfg.flows.flows_by_src[&0x10].is_empty());
+
+        let functions: BTreeSet<VA> = [0x0, 0x10].into_iter().collect();
+        let noret = cfg_prune_noret_functions(&module, &mut cfg, &functions)?;
+
+        assert!(noret.is_empty());
+        assert!(cfg.insns.insns_by_address.contains_key(&0x5));
+        assert!(cfg.insns.insns_by_address.contains_key(&0x6));
 
         Ok(())
     }

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -216,6 +216,12 @@ impl PEWorkspace {
             &names.addresses_by_name,
         )?);
 
+        noret.extend(crate::analysis::cfg::noret::cfg_prune_noret_functions(
+            &pe.module,
+            &mut cfg,
+            &function_starts,
+        )?);
+
         let thunks = crate::analysis::cfg::thunk::find_thunks(&cfg, function_starts.iter());
 
         let mut functions: BTreeMap<VA, FunctionAnalysis> = Default::default();
@@ -342,8 +348,14 @@ impl COFFWorkspace {
             .collect::<BTreeSet<VA>>();
         function_starts.extend(call_targets);
 
-        let noret =
+        let mut noret =
             crate::analysis::cfg::noret::cfg_prune_noret_by_name(&coff.module, &mut cfg, &names.addresses_by_name)?;
+
+        noret.extend(crate::analysis::cfg::noret::cfg_prune_noret_functions(
+            &coff.module,
+            &mut cfg,
+            &function_starts,
+        )?);
 
         let thunks = crate::analysis::cfg::thunk::find_thunks(&cfg, function_starts.iter());
 


### PR DESCRIPTION
Fixes #250. **Stacked on #257** (base branch is `claude/noret-names`; it needs the shared helper and the `cfg_mark_noret` recursion guard from that PR — merge #257 first and this retargets to master).

Adds `cfg::noret::cfg_prune_noret_functions`: a pass that marks functions as no-return from CFG shape alone, catching what name-based seeding can't — stripped and statically-linked binaries. A function is provably no-return only when *every* reachable path is a dead end: an infinite loop, `INT3`/`INT 0x29`/`INT 0x2C`, or a call whose fallthrough was already pruned as noret. It iterates to a fixpoint, since pruning one function's callers can make a caller provably no-return in turn.

The conservative gates are the heart of it — "unknown" always means "returns":
- any reachable `RET` → returns
- indirect unconditional jumps (tail call through the IAT or a register) → unknown
- **jumps that produce no flows at all** — unrecovered switch dispatches like `jmp [table + reg*4]` → unknown. This one is subtle: such jumps look like dead-end leaves. An earlier draft of this pass marked msvc's `memcpy` (whose copy dispatch is exactly this shape) as no-return; I caught it by disassembling what the pass flagged on `nop.exe`, and `noret_by_cfg_switch_dispatch_is_conservative` now pins the case.
- direct edges leaving the analyzed CFG → unknown

Both workspace constructors run the pass after name-based seeding.

Verification on real binaries (via `lancelot -v functions`):
- `nop.exe`: finds `__crtExitProcess` (0x401c4e) and the `_NMSG_WRITE`-style fatal writer (0x404bc8, ends in `__amsg_exit` + `int3`) *without using their names*; manually disassembled both to confirm. `memcpy` (0x4036b0) correctly not flagged.
- `cpp1.exe_`: finds four terminate-style handlers plus a thunk to one.

Tests (real CFGs, no mocks):
- `noret_by_cfg_infinite_loop`: `call B` where B is `jmp $` — B marked, post-call bytes pruned, and the *caller* becomes no-return via the fixpoint
- `noret_by_cfg_returning_functions_untouched`: callee plainly returns — nothing marked
- `noret_by_cfg_indirect_jump_is_conservative`: callee is `jmp [ptr]` — nothing marked
- `noret_by_cfg_switch_dispatch_is_conservative`: callee is `jmp [eax*4+table]` (no flows at all) — nothing marked
- full `cargo test -p lancelot --lib`: 130 passed, including the exact-match `ws_thunks` suite and all real-PE/COFF workspace tests; `cargo +nightly fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2

---
_Generated by [Claude Code](https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2)_