### PR TITLE
chore: dependency refresh and CLI dedup

### DIFF
--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -12,19 +12,16 @@ repository = "https://github.com/williballenthin/lancelot"
 
 [dependencies]
 log = "0.4"
-clap = "3"
-ansi_term = "0.12"
-hexyl = "0.15"
+clap = "4"
+nu-ansi-term = "0.50"
 fern = "0.7"
 chrono = "0.4"
 anyhow = "1"
-thiserror = "2"
 better-panic = "0.3"
 goblin = "0.9"
 # unreleased fixes for: https://github.com/mdsteele/rust-ar/issues/26
 # otherwise just use 0.9 or next release.
 ar = { git = "https://github.com/mdsteele/rust-ar", rev = "03d664b", version = "0.9" }
-hex = "0.4"
 serde_json = "1.0"
 sha256 = "1"
 

--- a/bin/src/bin/be2.rs
+++ b/bin/src/bin/be2.rs
@@ -11,28 +11,9 @@ use lancelot::{
 fn _main() -> Result<()> {
     better_panic::install();
 
-    let matches = clap::App::new("lancelot")
+    let matches = lancelot_bin::cli::add_config_arg(lancelot_bin::cli::add_common_args(clap::Command::new("be2")))
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("Binary analysis framework")
-        .arg(
-            clap::Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .multiple_occurrences(true)
-                .help("log verbose messages"),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .help("disable informational messages"),
-        )
-        .arg(
-            clap::Arg::new("configuration")
-                .long("config")
-                .takes_value(true)
-                .help("path to configuration directory"),
-        )
         .arg(
             clap::Arg::new("input")
                 .required(true)
@@ -41,55 +22,11 @@ fn _main() -> Result<()> {
         )
         .get_matches();
 
-    // --quiet overrides --verbose
-    let log_level = if matches.is_present("quiet") {
-        log::LevelFilter::Error
-    } else {
-        match matches.occurrences_of("verbose") {
-            0 => log::LevelFilter::Info,
-            1 => log::LevelFilter::Debug,
-            2 => log::LevelFilter::Trace,
-            _ => log::LevelFilter::Trace,
-        }
-    };
+    lancelot_bin::cli::configure_logging(&matches, &[]);
 
-    fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{} [{:5}] {} {}",
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                record.level(),
-                if log_level == log::LevelFilter::Trace {
-                    record.target()
-                } else {
-                    ""
-                },
-                message
-            ))
-        })
-        .level(log_level)
-        .chain(std::io::stderr())
-        .filter(|metadata| !metadata.target().starts_with("goblin::pe"))
-        .apply()
-        .expect("failed to configure logging");
+    let config = lancelot_bin::cli::configuration_from_matches(&matches);
 
-    // Enable ANSI support for Windows
-    // via: https://github.com/sharkdp/hexyl/blob/d1ae68585fe743d225bb39361bd383cb925b61f7/src/bin/hexyl.rs#L261
-    #[cfg(windows)]
-    let _ = ansi_term::enable_ansi_support();
-
-    let config = if matches.is_present("configuration") {
-        let path = matches.value_of("configuration").unwrap();
-        log::info!("configuration: {}", path);
-        Box::new(lancelot::workspace::config::FileSystemConfiguration::from_path(
-            &std::path::PathBuf::from(path),
-        ))
-    } else {
-        log::info!("using default, empty configuration");
-        lancelot::workspace::config::empty()
-    };
-
-    let filename = matches.value_of("input").unwrap();
+    let filename = matches.get_one::<String>("input").unwrap();
     debug!("input: {}", filename);
 
     let buf = util::read_file(filename)?;

--- a/bin/src/bin/jh.rs
+++ b/bin/src/bin/jh.rs
@@ -383,22 +383,9 @@ fn output_functions_features<W: std::io::Write>(
 fn _main() -> Result<()> {
     better_panic::install();
 
-    let matches = clap::App::new("jh")
+    let matches = lancelot_bin::cli::add_common_args(clap::Command::new("jh"))
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("extract interesting features from functions")
-        .arg(
-            clap::Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .multiple_occurrences(true)
-                .help("log verbose messages"),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .help("disable informational messages"),
-        )
         .arg(clap::Arg::new("triplet").required(true).index(1))
         .arg(clap::Arg::new("compiler").required(true).index(2))
         .arg(clap::Arg::new("library").required(true).index(3))
@@ -412,50 +399,20 @@ fn _main() -> Result<()> {
         )
         .get_matches();
 
-    // --quiet overrides --verbose
-    let log_level = if matches.is_present("quiet") {
-        log::LevelFilter::Error
-    } else {
-        match matches.occurrences_of("verbose") {
-            0 => log::LevelFilter::Info,
-            1 => log::LevelFilter::Debug,
-            2 => log::LevelFilter::Trace,
-            _ => log::LevelFilter::Trace,
-        }
-    };
+    // ignore warnings like: workspace: unknown file format: magic: 00 00
+    lancelot_bin::cli::configure_logging(&matches, &["lancelot::workspace"]);
 
     let build = BuildSettings {
-        triplet:  matches.value_of("triplet").unwrap().to_string(),
-        compiler: matches.value_of("compiler").unwrap().to_string(),
-        library:  matches.value_of("library").unwrap().to_string(),
-        version:  matches.value_of("version").unwrap().to_string(),
-        profile:  matches.value_of("profile").unwrap().to_string(),
+        triplet:  matches.get_one::<String>("triplet").unwrap().to_string(),
+        compiler: matches.get_one::<String>("compiler").unwrap().to_string(),
+        library:  matches.get_one::<String>("library").unwrap().to_string(),
+        version:  matches.get_one::<String>("version").unwrap().to_string(),
+        profile:  matches.get_one::<String>("profile").unwrap().to_string(),
     };
-
-    fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "[{:5}] {} {}",
-                record.level(),
-                if log_level == log::LevelFilter::Trace {
-                    record.target()
-                } else {
-                    ""
-                },
-                message
-            ))
-        })
-        .level(log_level)
-        .chain(std::io::stderr())
-        .filter(|metadata| !metadata.target().starts_with("goblin::pe"))
-        // ignore warnings like: workspace: unknown file format: magic: 00 00
-        .filter(|metadata| !metadata.target().starts_with("lancelot::workspace"))
-        .apply()
-        .expect("failed to configure logging");
 
     let config = empty();
 
-    let filename = matches.value_of("input").unwrap();
+    let filename = matches.get_one::<String>("input").unwrap();
 
     let buf = util::read_file(filename)?;
 

--- a/bin/src/bin/lancelot.rs
+++ b/bin/src/bin/lancelot.rs
@@ -77,30 +77,11 @@ fn parse_va(s: &str) -> Result<VA> {
 fn _main() -> Result<()> {
     better_panic::install();
 
-    let matches = clap::App::new("lancelot")
+    let matches = lancelot_bin::cli::add_config_arg(lancelot_bin::cli::add_common_args(clap::Command::new("lancelot")))
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("Binary analysis framework")
-        .arg(
-            clap::Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .multiple_occurrences(true)
-                .help("log verbose messages"),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .help("disable informational messages"),
-        )
-        .arg(
-            clap::Arg::new("configuration")
-                .long("config")
-                .takes_value(true)
-                .help("path to configuration directory"),
-        )
         .subcommand(
-            clap::App::new("functions").about("find functions").arg(
+            clap::Command::new("functions").about("find functions").arg(
                 clap::Arg::new("input")
                     .required(true)
                     .index(1)
@@ -108,7 +89,7 @@ fn _main() -> Result<()> {
             ),
         )
         .subcommand(
-            clap::App::new("disassemble")
+            clap::Command::new("disassemble")
                 .about("disassemble function")
                 .arg(
                     clap::Arg::new("input")
@@ -120,58 +101,14 @@ fn _main() -> Result<()> {
         )
         .get_matches();
 
-    // --quiet overrides --verbose
-    let log_level = if matches.is_present("quiet") {
-        log::LevelFilter::Error
-    } else {
-        match matches.occurrences_of("verbose") {
-            0 => log::LevelFilter::Info,
-            1 => log::LevelFilter::Debug,
-            2 => log::LevelFilter::Trace,
-            _ => log::LevelFilter::Trace,
-        }
-    };
+    lancelot_bin::cli::configure_logging(&matches, &[]);
 
-    fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{} [{:5}] {} {}",
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                record.level(),
-                if log_level == log::LevelFilter::Trace {
-                    record.target()
-                } else {
-                    ""
-                },
-                message
-            ))
-        })
-        .level(log_level)
-        .chain(std::io::stderr())
-        .filter(|metadata| !metadata.target().starts_with("goblin::pe"))
-        .apply()
-        .expect("failed to configure logging");
-
-    // Enable ANSI support for Windows
-    // via: https://github.com/sharkdp/hexyl/blob/d1ae68585fe743d225bb39361bd383cb925b61f7/src/bin/hexyl.rs#L261
-    #[cfg(windows)]
-    let _ = ansi_term::enable_ansi_support();
-
-    let config = if matches.is_present("configuration") {
-        let path = matches.value_of("configuration").unwrap();
-        log::info!("configuration: {}", path);
-        Box::new(lancelot::workspace::config::FileSystemConfiguration::from_path(
-            &std::path::PathBuf::from(path),
-        ))
-    } else {
-        log::info!("using default, empty configuration");
-        lancelot::workspace::config::empty()
-    };
+    let config = lancelot_bin::cli::configuration_from_matches(&matches);
 
     if let Some(matches) = matches.subcommand_matches("functions") {
         debug!("mode: find functions");
 
-        let filename = matches.value_of("input").unwrap();
+        let filename = matches.get_one::<String>("input").unwrap();
         debug!("input: {}", filename);
 
         let buf = util::read_file(filename)?;
@@ -181,10 +118,10 @@ fn _main() -> Result<()> {
     } else if let Some(matches) = matches.subcommand_matches("disassemble") {
         debug!("mode: disassemble");
 
-        let filename = matches.value_of("input").unwrap();
+        let filename = matches.get_one::<String>("input").unwrap();
         debug!("input: {}", filename);
 
-        let va = parse_va(matches.value_of("va").unwrap())?;
+        let va = parse_va(matches.get_one::<String>("va").unwrap())?;
 
         let buf = util::read_file(filename)?;
         let ws = workspace_from_bytes(config, &buf)?;

--- a/bin/src/bin/match_flirt.rs
+++ b/bin/src/bin/match_flirt.rs
@@ -11,22 +11,9 @@ use lancelot_flirt::*;
 fn _main() -> Result<()> {
     better_panic::install();
 
-    let matches = clap::App::new("match_flirt")
+    let matches = lancelot_bin::cli::add_common_args(clap::Command::new("match_flirt"))
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("Show FLIRT matches in the given file")
-        .arg(
-            clap::Arg::new("verbose")
-                .short('v')
-                .long("verbose")
-                .multiple_occurrences(true)
-                .help("log verbose messages"),
-        )
-        .arg(
-            clap::Arg::new("quiet")
-                .short('q')
-                .long("quiet")
-                .help("disable informational messages"),
-        )
         .arg(
             clap::Arg::new("input")
                 .required(true)
@@ -37,45 +24,15 @@ fn _main() -> Result<()> {
             clap::Arg::new("sig")
                 .required(true)
                 .index(2)
-                .multiple_values(true)
+                .num_args(1..)
                 .help("path to file to analyze"),
         )
         .get_matches();
 
-    // --quiet overrides --verbose
-    let log_level = if matches.is_present("quiet") {
-        log::LevelFilter::Error
-    } else {
-        match matches.occurrences_of("verbose") {
-            0 => log::LevelFilter::Info,
-            1 => log::LevelFilter::Debug,
-            2 => log::LevelFilter::Trace,
-            _ => log::LevelFilter::Trace,
-        }
-    };
-
-    fern::Dispatch::new()
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "{} [{:5}] {} {}",
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                record.level(),
-                if log_level == log::LevelFilter::Trace {
-                    record.target()
-                } else {
-                    ""
-                },
-                message
-            ))
-        })
-        .level(log_level)
-        .chain(std::io::stderr())
-        .filter(|metadata| !metadata.target().starts_with("goblin::pe"))
-        .apply()
-        .expect("failed to configure logging");
+    lancelot_bin::cli::configure_logging(&matches, &[]);
 
     let mut sigs = vec![];
-    for sigpath in matches.values_of("sig").unwrap() {
+    for sigpath in matches.get_many::<String>("sig").unwrap() {
         if sigpath.ends_with(".pat") {
             sigs.extend(pat::parse(&String::from_utf8(util::read_file(sigpath)?)?)?);
         } else if sigpath.ends_with(".sig") {
@@ -86,7 +43,7 @@ fn _main() -> Result<()> {
     }
     let sigs = FlirtSignatureSet::with_signatures(sigs);
 
-    let filename = matches.value_of("input").unwrap();
+    let filename = matches.get_one::<String>("input").unwrap();
     debug!("input: {}", filename);
 
     let buf = util::read_file(filename)?;

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -1,1 +1,96 @@
 extern crate log;
+
+/// shared plumbing for the lancelot CLI tools:
+/// common arguments, logging setup, and workspace configuration.
+pub mod cli {
+    /// add the standard `--verbose`/`--quiet` arguments.
+    pub fn add_common_args(cmd: clap::Command) -> clap::Command {
+        cmd.arg(
+            clap::Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(clap::ArgAction::Count)
+                .help("log verbose messages"),
+        )
+        .arg(
+            clap::Arg::new("quiet")
+                .short('q')
+                .long("quiet")
+                .action(clap::ArgAction::SetTrue)
+                .help("disable informational messages"),
+        )
+    }
+
+    /// configure logging according to the standard `--verbose`/`--quiet`
+    /// arguments (see [`add_common_args`]).
+    ///
+    /// messages from the given targets are suppressed,
+    /// in addition to the always-noisy `goblin::pe`.
+    pub fn configure_logging(matches: &clap::ArgMatches, ignored_targets: &'static [&'static str]) {
+        // --quiet overrides --verbose
+        let log_level = if matches.get_flag("quiet") {
+            log::LevelFilter::Error
+        } else {
+            match matches.get_count("verbose") {
+                0 => log::LevelFilter::Info,
+                1 => log::LevelFilter::Debug,
+                _ => log::LevelFilter::Trace,
+            }
+        };
+
+        fern::Dispatch::new()
+            .format(move |out, message, record| {
+                out.finish(format_args!(
+                    "{} [{:5}] {} {}",
+                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                    record.level(),
+                    if log_level == log::LevelFilter::Trace {
+                        record.target()
+                    } else {
+                        ""
+                    },
+                    message
+                ))
+            })
+            .level(log_level)
+            .chain(std::io::stderr())
+            .filter(|metadata| !metadata.target().starts_with("goblin::pe"))
+            .filter(move |metadata| {
+                !ignored_targets
+                    .iter()
+                    .any(|target| metadata.target().starts_with(target))
+            })
+            .apply()
+            .expect("failed to configure logging");
+
+        // Enable ANSI support for Windows
+        // via: https://github.com/sharkdp/hexyl/blob/d1ae68585fe743d225bb39361bd383cb925b61f7/src/bin/hexyl.rs#L261
+        #[cfg(windows)]
+        let _ = nu_ansi_term::enable_ansi_support();
+    }
+
+    /// add the standard `--config` argument.
+    pub fn add_config_arg(cmd: clap::Command) -> clap::Command {
+        cmd.arg(
+            clap::Arg::new("configuration")
+                .long("config")
+                .help("path to configuration directory"),
+        )
+    }
+
+    /// build the workspace configuration according to the standard `--config`
+    /// argument (see [`add_config_arg`]).
+    pub fn configuration_from_matches(
+        matches: &clap::ArgMatches,
+    ) -> Box<dyn lancelot::workspace::config::Configuration> {
+        if let Some(path) = matches.get_one::<String>("configuration") {
+            log::info!("configuration: {}", path);
+            Box::new(lancelot::workspace::config::FileSystemConfiguration::from_path(
+                &std::path::PathBuf::from(path),
+            ))
+        } else {
+            log::info!("using default, empty configuration");
+            lancelot::workspace::config::empty()
+        }
+    }
+}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,15 +18,14 @@ goblin = { version = "0.10", features = ["std", "pe32"], default-features = fals
 object = "0.36"
 zydis = { features = ["serialization", "nolibc"], optional = true, version = "4.1.1" }
 byteorder = "1"
-bitflags = "1"
-lazy_static = "1"
+bitflags = "2"
 anyhow = "1"
 thiserror = "2"
 regex = "1"
 smallvec = "1"
 widestring = "1.0"
 smol_str = "0.3"
-ansi_term = "0.12"
+nu-ansi-term = "0.50"
 chrono = { version = "0.4", features = ["clock"], default-features = false}
 
 # fern is only needed by tests, but because of the need for a feature named

--- a/core/src/analysis/pe/patterns.rs
+++ b/core/src/analysis/pe/patterns.rs
@@ -6,145 +6,138 @@ use regex::bytes::Regex;
 
 use crate::{aspace::AddressSpace, loader::pe::PE, VA};
 
-lazy_static! {
-    static ref PATTERNS: Regex = {
+static PATTERNS: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    // CC debug filler, x86win_patterns.xml#L4
+    let CC = r"\xCC";
+    // multiple CC filler bytes, x86win_patterns.xml#L5
+    let CCCC = r"\xCC\xCC";
+    // NOP filler, x86win_patterns.xml#L6
+    let NOP = r"\x90";
+    // RET filler, x86win_patterns.xml#L7
+    let RET = r"\xC3";
+    // LEAVE RET, x86win_patterns.xml#L8
+    let LEAVE_RET = r"\xC9\xC3";
 
-        // CC debug filler, x86win_patterns.xml#L4
-        let CC = r"\xCC";
-        // multiple CC filler bytes, x86win_patterns.xml#L5
-        let CCCC = r"\xCC\xCC";
-        // NOP filler, x86win_patterns.xml#L6
-        let NOP = r"\x90";
-        // RET filler, x86win_patterns.xml#L7
-        let RET = r"\xC3";
-        // LEAVE RET, x86win_patterns.xml#L8
-        let LEAVE_RET = r"\xC9\xC3";
+    // JMP DWORD PTR ds:????????
+    // mimikatz:0x46B674
+    let JMP_FAR = r"\xFF\x25....";
 
-        // JMP DWORD PTR ds:????????
-        // mimikatz:0x46B674
-        let JMP_FAR = r"\xFF\x25....";
+    // RETN ???
+    // mimikatz:0x45D025
+    let RETN = r"\xC2..";
 
-        // RETN ???
-        // mimikatz:0x45D025
-        let RETN = r"\xC2..";
+    // x86win_patterns.xml#L9
+    // 0xC2 ......00 0x00
+    // let RET_LONGFORM =
 
-        // x86win_patterns.xml#L9
-        // 0xC2 ......00 0x00
-        // let RET_LONGFORM =
+    let PREPATTERN = format!(
+        "(?P<prepattern>{})",
+        [CC, CCCC, NOP, RET, LEAVE_RET, JMP_FAR, RETN,].join("|")
+    );
 
-        let PREPATTERN = format!("(?P<prepattern>{})", [
-            CC,
-            CCCC,
-            NOP,
-            RET,
-            LEAVE_RET,
-            JMP_FAR,
-            RETN,
-        ].join("|"));
+    // PUSH EBP; MOV EBP, ESP, x86win_patterns.xml#L12
+    let P0 = r"\x55\x8B\xEC";
 
-        // PUSH EBP; MOV EBP, ESP, x86win_patterns.xml#L12
-        let P0 = r"\x55\x8B\xEC";
+    // x86win_patterns.xml#L13
+    //  SUB ESP, #small
+    // <data>0x83ec 0.....00 </data>
+    //let P1 = r"\x83\xEC (
+    //  \x00|\x04|\x08|\x0c|\x10|\x14|\x18|\x1c|
+    //  \x20|\x24|\x28|\x2c|\x30|\x34|\x38|\x3c|
+    //  \x40|\x44|\x48|\x4c|\x50|\x54|\x58|\x5c|
+    //  \x60|\x64|\x68|\x6c|\x70|\x74|\x78|\x7c)";
 
-        // x86win_patterns.xml#L13
-        //  SUB ESP, #small
-        // <data>0x83ec 0.....00 </data>
-        //let P1 = r"\x83\xEC (
-        //  \x00|\x04|\x08|\x0c|\x10|\x14|\x18|\x1c|
-        //  \x20|\x24|\x28|\x2c|\x30|\x34|\x38|\x3c|
-        //  \x40|\x44|\x48|\x4c|\x50|\x54|\x58|\x5c|
-        //  \x60|\x64|\x68|\x6c|\x70|\x74|\x78|\x7c)";
+    // x86win_patterns.xml#L14
+    //  PUSH-1; PUSH FUNC; MOV EAX, FS[0]
+    // <data>0x6aff68........64a100000000 </data>
+    //let P2 = r"\x6A\xFF\x68....\x64\xA1\x00\x00\x00\x00";
 
-        // x86win_patterns.xml#L14
-        //  PUSH-1; PUSH FUNC; MOV EAX, FS[0]
-        // <data>0x6aff68........64a100000000 </data>
-        //let P2 = r"\x6A\xFF\x68....\x64\xA1\x00\x00\x00\x00";
+    // x86win_patterns.xml#L15
+    //   PUSH ESI; MOV ESI, ECX
+    // <data>0x568bf1 </data>
+    //let P3 = r"\x56\x8B\xF1";
 
-        // x86win_patterns.xml#L15
-        //   PUSH ESI; MOV ESI, ECX
-        // <data>0x568bf1 </data>
-        //let P3 = r"\x56\x8B\xF1";
+    // x86win_patterns.xml#L16
+    //   MOV EAX, ??; CALL; SUB ESP
+    // <data>0xb8........e8........ 100000.1 0xec</data>
+    // let P4 = r"";
 
-        // x86win_patterns.xml#L16
-        //   MOV EAX, ??; CALL; SUB ESP
-        // <data>0xb8........e8........ 100000.1 0xec</data>
-        // let P4 = r"";
+    // x86win_patterns.xml#L17
+    //    MOV EAX, ??; CALL
+    // <data>0xb8........e8</data>
+    // let P5 = r"";
 
-        // x86win_patterns.xml#L17
-        //    MOV EAX, ??; CALL
-        // <data>0xb8........e8</data>
-        // let P5 = r"";
+    // x86win_patterns.xml#L18
+    //    MOV EDI,EDI : PUSH EBP : MOV EBP,ESP
+    // <data>0x8bff558bec</data>
+    let P6 = r"\x8B\xFF\x55\x8B\xEC";
 
-        // x86win_patterns.xml#L18
-        //    MOV EDI,EDI : PUSH EBP : MOV EBP,ESP
-        // <data>0x8bff558bec</data>
-        let P6 = r"\x8B\xFF\x55\x8B\xEC";
+    // x86win_patterns.xml#L20
+    //  PUSH EBX : MOV EBX,E*X
+    // <data>0x538b 110110..</data>
+    // let P7 = r"";
 
-        // x86win_patterns.xml#L20
-        //  PUSH EBX : MOV EBX,E*X
-        // <data>0x538b 110110..</data>
-        // let P7 = r"";
+    // x86win_patterns.xml#L21
+    //   PUSH EBX : PUSH ESI : PUSH EDI
+    // <data>0x535657</data>
+    // let P8 = r"";
 
-        // x86win_patterns.xml#L21
-        //   PUSH EBX : PUSH ESI : PUSH EDI
-        // <data>0x535657</data>
-        // let P8 = r"";
+    // x86win_patterns.xml#L22
+    //   PUSH EBX : PUSH EBP : PUSH ESI
+    // <data>0x535556</data>
+    // let P9 = r"";
 
-        // x86win_patterns.xml#L22
-        //   PUSH EBX : PUSH EBP : PUSH ESI
-        // <data>0x535556</data>
-        // let P9 = r"";
+    // x86win_patterns.xml#L23
+    //  PUSH EBX : PUSH ESI : PUSH ECX
+    // <data>0x535651</data>
+    // let P10 = r"";
 
-        // x86win_patterns.xml#L23
-        //  PUSH EBX : PUSH ESI : PUSH ECX
-        // <data>0x535651</data>
-        // let P10 = r"";
+    // x86win_patterns.xml#L25
+    //   PUSH EBX : PUSH ESI : MOV ESI,EDX
+    // <data>0x53568bf2</data>
+    // let P11 = r"";
 
-        // x86win_patterns.xml#L25
-        //   PUSH EBX : PUSH ESI : MOV ESI,EDX
-        // <data>0x53568bf2</data>
-        // let P11 = r"";
+    // x86win_patterns.xml#L26
+    //   PUSH EBX : PUSH ESI : MOV EBX,EAX
+    // <data>0x53568bd8</data>
+    // let P12 = r"";
 
-        // x86win_patterns.xml#L26
-        //   PUSH EBX : PUSH ESI : MOV EBX,EAX
-        // <data>0x53568bd8</data>
-        // let P12 = r"";
+    // x86win_patterns.xml#L27
+    //   PUSH EBX : PUSH ESI : MOV ESI,ECX
+    // <data>0x53568bf1</data>
+    // let P13 = r"";
 
-        // x86win_patterns.xml#L27
-        //   PUSH EBX : PUSH ESI : MOV ESI,ECX
-        // <data>0x53568bf1</data>
-        // let P13 = r"";
+    // x86win_patterns.xml#L28
+    //   PUSH EBX : PUSH ESI : MOV EBX,EDX
+    // <data>0x53568bda</data>
+    // let P14 = r"";
 
-        // x86win_patterns.xml#L28
-        //   PUSH EBX : PUSH ESI : MOV EBX,EDX
-        // <data>0x53568bda</data>
-        // let P14 = r"";
+    // x86win_patterns.xml#L29
+    //   PUSH EBX : PUSH ESI : MOV ESI,EAX
+    // <data>0x53568bf0</data>
+    // let P15 = r"";
 
-        // x86win_patterns.xml#L29
-        //   PUSH EBX : PUSH ESI : MOV ESI,EAX
-        // <data>0x53568bf0</data>
-        // let P15 = r"";
+    // x86win_patterns.xml#L30
+    //   PUSH ESI : PUSH EDI : MOV EDI,ECX
+    // <data>0x56578bf9</data>
+    // let P16 = r"";
 
-        // x86win_patterns.xml#L30
-        //   PUSH ESI : PUSH EDI : MOV EDI,ECX
-        // <data>0x56578bf9</data>
-        // let P16 = r"";
+    // x86win_patterns.xml#L31
+    //   PUSH ESI : PUSH EDI : MOV ESI,ECX
+    // <data>0x56578bf1</data>
+    // let P17 = r"";
 
-        // x86win_patterns.xml#L31
-        //   PUSH ESI : PUSH EDI : MOV ESI,ECX
-        // <data>0x56578bf1</data>
-        // let P17 = r"";
-
-        // x64 msvc prologue
-        // see #100
-        //
-        //     .text:0000000140001060 48 89 54 24 10       mov     [rsp+arg_8], rdx
-        //     .text:0000000140001065 4C 89 44 24 18       mov     [rsp+arg_10], r8
-        //     .text:000000014000106A 4C 89 4C 24 20       mov     [rsp+arg_18], r9
-        //     .text:000000014000106F 53                   push    rbx
-        //     .text:0000000140001070 56                   push    rsi
-        //     .text:0000000140001071 57                   push    rdi
-        //     .text:0000000140001072 48 83 EC 30          sub     rsp, 30h
-        let P18 = r"
+    // x64 msvc prologue
+    // see #100
+    //
+    //     .text:0000000140001060 48 89 54 24 10       mov     [rsp+arg_8], rdx
+    //     .text:0000000140001065 4C 89 44 24 18       mov     [rsp+arg_10], r8
+    //     .text:000000014000106A 4C 89 4C 24 20       mov     [rsp+arg_18], r9
+    //     .text:000000014000106F 53                   push    rbx
+    //     .text:0000000140001070 56                   push    rsi
+    //     .text:0000000140001071 57                   push    rdi
+    //     .text:0000000140001072 48 83 EC 30          sub     rsp, 30h
+    let P18 = r"
             (?:
                 (?: \x48|\x4C ) \x89 . \x24 .    # mov  [rsp+??], ??
             )+
@@ -152,32 +145,27 @@ lazy_static! {
             \x48 \x83 \xEC .                     # sub  rsp, ??
         ";
 
-        // x64 msvc prologue
-        //
-        //     .text:000000014004742B 40 55                push    rbp
-        //     .text:000000014004742D 48 83 EC 20          sub     rsp, 20h
-        let P19 = r"
+    // x64 msvc prologue
+    //
+    //     .text:000000014004742B 40 55                push    rbp
+    //     .text:000000014004742D 48 83 EC 20          sub     rsp, 20h
+    let P19 = r"
             \x40 \x55                            # push rbp
             \x48 \x83 \xEC .                     # sub  rsp, ??
         ";
 
-        let POSTPATTERN = format!("(?P<postpattern>{})", [
-            P0,
-            P6,
-            P18,
-            P19,
-        ].join("|"));
+    let POSTPATTERN = format!("(?P<postpattern>{})", [P0, P6, P18, P19,].join("|"));
 
-        let re = format!(
-            r"(?x)                # whitespace allowed
+    let re = format!(
+        r"(?x)                # whitespace allowed
               (?-u)               # disable unicode mode, so we can match raw bytes
               (:?{PREPATTERN})    # capture the pre match
               (:?{POSTPATTERN})   # capture the match
-            ");
+            "
+    );
 
-        Regex::new(&re).unwrap()
-    };
-}
+    Regex::new(&re).unwrap()
+});
 
 #[allow(dead_code)]
 const INDEX_ALL: usize = 0;

--- a/core/src/emu/mmu.rs
+++ b/core/src/emu/mmu.rs
@@ -100,15 +100,16 @@ impl std::ops::IndexMut<PFN> for PageFrames {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct PageFlags: u32 {
         /// matches [crate::module::Permissions]
         const PERM_R = 0b00000001;
         const PERM_W = 0b00000010;
         const PERM_X = 0b00000100;
-        const PERM_RW = Self::PERM_R.bits | Self::PERM_W.bits;
-        const PERM_RX =  Self::PERM_R.bits | Self::PERM_X.bits;
-        const PERM_WX =  Self::PERM_W.bits | Self::PERM_X.bits;
-        const PERM_RWX =  Self::PERM_R.bits | Self::PERM_W.bits | Self::PERM_X.bits;
+        const PERM_RW = Self::PERM_R.bits() | Self::PERM_W.bits();
+        const PERM_RX = Self::PERM_R.bits() | Self::PERM_X.bits();
+        const PERM_WX = Self::PERM_W.bits() | Self::PERM_X.bits();
+        const PERM_RWX = Self::PERM_R.bits() | Self::PERM_W.bits() | Self::PERM_X.bits();
 
         /// a zero page, not backed by a Page Frame.
         /// upon write, allocate Page Frame on demand.

--- a/core/src/emu/plat/win/api.rs
+++ b/core/src/emu/plat/win/api.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 
+use std::sync::LazyLock;
+
 use anyhow::Result;
-use lazy_static::lazy_static;
 
 use super::WindowsEmulator;
 
@@ -23,60 +24,56 @@ pub struct FunctionDescriptor {
 
 type Hook = Box<dyn Fn(&mut dyn WindowsEmulator, &FunctionDescriptor) -> Result<()> + Send + Sync>;
 
-lazy_static! {
-    pub static ref API: BTreeMap<String, FunctionDescriptor> = {
-        let mut m = BTreeMap::new();
+pub static API: LazyLock<BTreeMap<String, FunctionDescriptor>> = LazyLock::new(|| {
+    let mut m = BTreeMap::new();
 
-        // populate from: https://github.com/microsoft/windows-rs/blob/master/.windows/winmd/Windows.Win32.winmd
-        // alternative source: https://github.com/vivisect/vivisect/blob/master/vivisect/impapi/windows/i386.py
-        // alternative source: https://github.com/fireeye/speakeasy/blob/88502c6eb99dd21ca6ebdcba3edff42c9c2c1bf8/speakeasy/winenv/api/usermode/kernel32.py#L1192
+    // populate from: https://github.com/microsoft/windows-rs/blob/master/.windows/winmd/Windows.Win32.winmd
+    // alternative source: https://github.com/vivisect/vivisect/blob/master/vivisect/impapi/windows/i386.py
+    // alternative source: https://github.com/fireeye/speakeasy/blob/88502c6eb99dd21ca6ebdcba3edff42c9c2c1bf8/speakeasy/winenv/api/usermode/kernel32.py#L1192
 
-        m.insert(
-            String::from("kernel32.dll!GetVersionExA"),
-            FunctionDescriptor {
-                calling_convention: CallingConvention::Stdcall,
-                return_type: String::from("bool"),
-                arguments: vec![
-                    ArgumentDescriptor {
-                        ty: String::from("LPOSVERSIONINFOA"),
-                        name: String::from("lpVersionInformation"),
+    m.insert(
+        String::from("kernel32.dll!GetVersionExA"),
+        FunctionDescriptor {
+            calling_convention: CallingConvention::Stdcall,
+            return_type:        String::from("bool"),
+            arguments:          vec![ArgumentDescriptor {
+                ty:   String::from("LPOSVERSIONINFOA"),
+                name: String::from("lpVersionInformation"),
+            }],
+        },
+    );
+
+    m
+});
+
+pub static HOOKS: LazyLock<BTreeMap<String, Hook>> = LazyLock::new(|| {
+    let mut m = BTreeMap::new();
+
+    m.insert(
+        String::from("kernel32.dll!GetVersionExA"),
+        Box::new(
+            move |emu: &mut dyn WindowsEmulator, desc: &FunctionDescriptor| -> Result<()> {
+                let ra = emu.pop()?;
+                emu.set_pc(ra);
+
+                // this is 32-bit land
+                if let CallingConvention::Stdcall = desc.calling_convention {
+                    for _ in 0..desc.arguments.len() {
+                        let _ = emu.pop()?;
                     }
-                ]
-            }
-        );
-
-        m
-    };
-
-    pub static ref HOOKS: BTreeMap<String, Hook> = {
-        let mut m = BTreeMap::new();
-
-        m.insert(
-            String::from("kernel32.dll!GetVersionExA"),
-            Box::new(
-                move |emu: &mut dyn WindowsEmulator, desc: &FunctionDescriptor| -> Result<()> {
-                    let ra = emu.pop()?;
-                    emu.set_pc(ra);
-
-                    // this is 32-bit land
-                    if let CallingConvention::Stdcall = desc.calling_convention {
-                        for _ in 0..desc.arguments.len() {
-                            let _ = emu.pop()?;
-                        }
-                    }
-
-                    // TODO:
-
-                    // this is 64-bit
-                    // emu.inner.set_rax(0);
-
-                    //emu.handle_return(0, desc)?;
-
-                    Ok(())
                 }
-            ) as Hook
-        );
 
-        m
-    };
-}
+                // TODO:
+
+                // this is 64-bit
+                // emu.inner.set_rax(0);
+
+                //emu.handle_return(0, desc)?;
+
+                Ok(())
+            },
+        ) as Hook,
+    );
+
+    m
+});

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::upper_case_acronyms)]
 
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 extern crate log;
 
 pub mod analysis;

--- a/core/src/module.rs
+++ b/core/src/module.rs
@@ -18,14 +18,15 @@ pub enum ModuleError {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Permissions: u8 {
         const R = 0b0000_0001;
         const W = 0b0000_0010;
         const X = 0b0000_0100;
-        const RW = Self::R.bits | Self::W.bits;
-        const RX =  Self::R.bits | Self::X.bits;
-        const WX =  Self::W.bits | Self::X.bits;
-        const RWX =  Self::R.bits | Self::W.bits | Self::X.bits;
+        const RW = Self::R.bits() | Self::W.bits();
+        const RX = Self::R.bits() | Self::X.bits();
+        const WX = Self::W.bits() | Self::X.bits();
+        const RWX = Self::R.bits() | Self::W.bits() | Self::X.bits();
     }
 }
 

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -198,9 +198,7 @@ pub fn read_file(filename: &str) -> Result<Vec<u8>> {
 }
 
 pub fn find_ascii_strings(buf: &[u8]) -> impl Iterator<Item = (Range<usize>, String)> + '_ {
-    lazy_static! {
-        static ref ASCII_RE: Regex = Regex::new("[ -~]{4,}").unwrap();
-    }
+    static ASCII_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new("[ -~]{4,}").unwrap());
 
     ASCII_RE.captures_iter(buf).map(|cap| {
         // guaranteed to have at least one hit
@@ -220,9 +218,7 @@ pub fn find_ascii_strings(buf: &[u8]) -> impl Iterator<Item = (Range<usize>, Str
 }
 
 pub fn find_unicode_strings(buf: &[u8]) -> impl Iterator<Item = (Range<usize>, String)> + '_ {
-    lazy_static! {
-        static ref UNICODE_RE: Regex = Regex::new("([ -~]\x00){4,}").unwrap();
-    }
+    static UNICODE_RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| Regex::new("([ -~]\x00){4,}").unwrap());
 
     UNICODE_RE.captures_iter(buf).map(|cap| {
         // guaranteed to have at least one hit

--- a/core/src/workspace/formatter.rs
+++ b/core/src/workspace/formatter.rs
@@ -79,25 +79,25 @@ pub const TOKEN_USER_HEX: zydis::Token = zydis::Token(zydis::TOKEN_USER.0 + 2);
 impl Formatter {
     // default theme
     // TODO: move this to a struct that can be configured
-    const COLOR_ADDRESS_ABS: ansi_term::Color = ansi_term::Color::Blue;
-    const COLOR_ADDRESS_REL: ansi_term::Color = ansi_term::Color::Blue;
-    const COLOR_DECORATOR: ansi_term::Color = Formatter::GREY;
-    const COLOR_DELIMITER: ansi_term::Color = Formatter::GREY;
-    const COLOR_DISPLACEMENT: ansi_term::Color = ansi_term::Color::Blue;
-    const COLOR_HEX: ansi_term::Color = ansi_term::Color::Cyan;
-    const COLOR_IMMEDIATE: ansi_term::Color = ansi_term::Color::Blue;
-    const COLOR_INVALID: ansi_term::Color = ansi_term::Color::Red;
-    const COLOR_MNEMONIC: ansi_term::Color = ansi_term::Color::Green;
-    const COLOR_PARENTHESIS_CLOSE: ansi_term::Color = Formatter::GREY;
-    const COLOR_PARENTHESIS_OPEN: ansi_term::Color = Formatter::GREY;
-    const COLOR_PREFIX: ansi_term::Color = Formatter::GREY;
-    const COLOR_REGISTER: ansi_term::Color = ansi_term::Color::Yellow;
-    const COLOR_SYMBOL: ansi_term::Color = Formatter::GREY;
-    const COLOR_SYMBOLNAME: ansi_term::Color = ansi_term::Color::Purple;
-    const COLOR_TYPECAST: ansi_term::Color = Formatter::GREY;
-    const COLOR_USER: ansi_term::Color = Formatter::GREY;
-    const COLOR_WHITESPACE: ansi_term::Color = ansi_term::Color::Black;
-    const GREY: ansi_term::Color = ansi_term::Color::Fixed(242);
+    const COLOR_ADDRESS_ABS: nu_ansi_term::Color = nu_ansi_term::Color::Blue;
+    const COLOR_ADDRESS_REL: nu_ansi_term::Color = nu_ansi_term::Color::Blue;
+    const COLOR_DECORATOR: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_DELIMITER: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_DISPLACEMENT: nu_ansi_term::Color = nu_ansi_term::Color::Blue;
+    const COLOR_HEX: nu_ansi_term::Color = nu_ansi_term::Color::Cyan;
+    const COLOR_IMMEDIATE: nu_ansi_term::Color = nu_ansi_term::Color::Blue;
+    const COLOR_INVALID: nu_ansi_term::Color = nu_ansi_term::Color::Red;
+    const COLOR_MNEMONIC: nu_ansi_term::Color = nu_ansi_term::Color::Green;
+    const COLOR_PARENTHESIS_CLOSE: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_PARENTHESIS_OPEN: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_PREFIX: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_REGISTER: nu_ansi_term::Color = nu_ansi_term::Color::Yellow;
+    const COLOR_SYMBOL: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_SYMBOLNAME: nu_ansi_term::Color = nu_ansi_term::Color::Purple;
+    const COLOR_TYPECAST: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_USER: nu_ansi_term::Color = Formatter::GREY;
+    const COLOR_WHITESPACE: nu_ansi_term::Color = nu_ansi_term::Color::Black;
+    const GREY: nu_ansi_term::Color = nu_ansi_term::Color::Fixed(242);
 
     #[must_use]
     pub fn new() -> Formatter {
@@ -312,7 +312,7 @@ impl Formatter {
         Formatter { options, inner, orig }
     }
 
-    fn get_token_color(token: zydis::Token) -> ansi_term::Color {
+    fn get_token_color(token: zydis::Token) -> nu_ansi_term::Color {
         match token {
             zydis::TOKEN_INVALID => Formatter::COLOR_INVALID,
             zydis::TOKEN_WHITESPACE => Formatter::COLOR_WHITESPACE,

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -44,6 +44,7 @@ pub enum WorkspaceError {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct FunctionFlags: u8 {
         const NORET = 0b0000_0001;
         const THUNK = 0b0000_0010;

--- a/flirt/Cargo.toml
+++ b/flirt/Cargo.toml
@@ -15,18 +15,40 @@ log = "0.4"
 nom = "7"
 regex = "1.3"
 bitvec = "1"
-clap = "3"
-fern = "0.7"
-chrono = { version = "0.4", features = ["std", "clock"], default-features = false }
-better-panic = "0.3"
 inflate = "0.4"
 anyhow = "1"
 thiserror = "2"
-bitflags = "1"
+bitflags = "2"
 smallvec = "1"
+
+# only used by the helper binaries (sig2pat, parsepat, decompress_sig),
+# gated behind the `cli` feature so that library consumers -- including
+# the wasm build via the core crate -- don't pull them in.
+clap = { version = "4", optional = true }
+fern = { version = "0.7", optional = true }
+chrono = { version = "0.4", features = ["std", "clock"], default-features = false, optional = true }
+better-panic = { version = "0.3", optional = true }
+
+[features]
+cli = ["dep:clap", "dep:fern", "dep:chrono", "dep:better-panic"]
+
+[[bin]]
+name = "sig2pat"
+required-features = ["cli"]
+
+[[bin]]
+name = "parsepat"
+required-features = ["cli"]
+
+[[bin]]
+name = "decompress_sig"
+required-features = ["cli"]
 
 [dev-dependencies]
 criterion = "0.5"
+# used by test helpers (init_logging)
+fern = "0.7"
+chrono = { version = "0.4", features = ["std", "clock"], default-features = false }
 
 [[bench]]
 name = "regex"

--- a/flirt/src/bin/decompress_sig.rs
+++ b/flirt/src/bin/decompress_sig.rs
@@ -12,14 +12,14 @@ fn run(sig_path: &str, output_path: &str) -> Result<()> {
 fn main() {
     better_panic::install();
 
-    let matches = clap::App::new("decompress_sig")
+    let matches = clap::Command::new("decompress_sig")
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("decompress a FLIRT .sig file with compression into one without compression")
         .arg(
             clap::Arg::new("verbose")
                 .short('v')
                 .long("verbose")
-                .multiple_occurrences(true)
+                .action(clap::ArgAction::Count)
                 .help("log verbose messages"),
         )
         .arg(clap::Arg::new("sig").required(true).index(1).help("path to .sig file"))
@@ -31,7 +31,7 @@ fn main() {
         )
         .get_matches();
 
-    let log_level = match matches.occurrences_of("verbose") {
+    let log_level = match matches.get_count("verbose") {
         0 => log::LevelFilter::Info,
         1 => log::LevelFilter::Debug,
         2 => log::LevelFilter::Trace,
@@ -57,7 +57,10 @@ fn main() {
         .apply()
         .expect("failed to configure logging");
 
-    if let Err(e) = run(matches.value_of("sig").unwrap(), matches.value_of("output").unwrap()) {
+    if let Err(e) = run(
+        matches.get_one::<String>("sig").unwrap(),
+        matches.get_one::<String>("output").unwrap(),
+    ) {
         eprintln!("error: {e}");
     }
 }

--- a/flirt/src/bin/parsepat.rs
+++ b/flirt/src/bin/parsepat.rs
@@ -13,20 +13,20 @@ fn run(pat_path: &str) -> Result<()> {
 fn main() {
     better_panic::install();
 
-    let matches = clap::App::new("parsepat")
+    let matches = clap::Command::new("parsepat")
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("parse a .pat file and... do nothing.")
         .arg(
             clap::Arg::new("verbose")
                 .short('v')
                 .long("verbose")
-                .multiple_occurrences(true)
+                .action(clap::ArgAction::Count)
                 .help("log verbose messages"),
         )
         .arg(clap::Arg::new("pat").required(true).index(1).help("path to .pat file"))
         .get_matches();
 
-    let log_level = match matches.occurrences_of("verbose") {
+    let log_level = match matches.get_count("verbose") {
         0 => log::LevelFilter::Info,
         1 => log::LevelFilter::Debug,
         2 => log::LevelFilter::Trace,
@@ -52,7 +52,7 @@ fn main() {
         .apply()
         .expect("failed to configure logging");
 
-    if let Err(e) = run(matches.value_of("pat").unwrap()) {
+    if let Err(e) = run(matches.get_one::<String>("pat").unwrap()) {
         eprintln!("error: {e:}");
     }
 }

--- a/flirt/src/bin/sig2pat.rs
+++ b/flirt/src/bin/sig2pat.rs
@@ -13,20 +13,20 @@ fn run(sig_path: &str) -> Result<()> {
 fn main() {
     better_panic::install();
 
-    let matches = clap::App::new("sig2pat")
+    let matches = clap::Command::new("sig2pat")
         .author("Willi Ballenthin <william.ballenthin@mandiant.com>")
         .about("translate a FLIRT .sig file into a .pat file")
         .arg(
             clap::Arg::new("verbose")
                 .short('v')
                 .long("verbose")
-                .multiple_occurrences(true)
+                .action(clap::ArgAction::Count)
                 .help("log verbose messages"),
         )
         .arg(clap::Arg::new("sig").required(true).index(1).help("path to .sig file"))
         .get_matches();
 
-    let log_level = match matches.occurrences_of("verbose") {
+    let log_level = match matches.get_count("verbose") {
         0 => log::LevelFilter::Info,
         1 => log::LevelFilter::Debug,
         2 => log::LevelFilter::Trace,
@@ -52,7 +52,7 @@ fn main() {
         .apply()
         .expect("failed to configure logging");
 
-    if let Err(e) = run(matches.value_of("sig").unwrap()) {
+    if let Err(e) = run(matches.get_one::<String>("sig").unwrap()) {
         eprintln!("error: {e}");
     }
 }

--- a/flirt/src/sig/mod.rs
+++ b/flirt/src/sig/mod.rs
@@ -25,6 +25,7 @@ pub enum SigError {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct Features: u16 {
         const STARTUP        = 0b0000_0001;
         const CTYPE_CRC      = 0b0000_0010;
@@ -292,6 +293,7 @@ fn wildcard_mask(input: &[u8], length: u16) -> IResult<&[u8], u64> {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct ParsingFlags: u8 {
         const MORE_PUBLIC_NAMES = 0b0000_0001;
         const TAIL_BYTES = 0b0000_0010;
@@ -302,6 +304,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     struct NameFlags: u8 {
         const UNK1  = 0b0000_0001;
         const LOCAL = 0b0000_0010;


### PR DESCRIPTION
Fixes #251.

- **bitflags 1 → 2**: core `Permissions`/`FunctionFlags`/`PageFlags`, flirt `Features`/`ParsingFlags`/`NameFlags`. `.bits` field → `.bits()`, plus the explicit `#[derive(...)]`s that bitflags 2 requires.
- **lazy_static → `std::sync::LazyLock`** (string-scan regexes in `util`, prologue `PATTERNS`, emu win32 API tables); one dependency gone.
- **ansi_term → nu-ansi-term**: ansi_term is unmaintained (RUSTSEC-2021-0139); nu-ansi-term is the maintained fork with the same API, so this is a rename-only change in the formatter and CLI tools.
- **clap 3 → 4** across `bin/` and flirt's helper binaries (`App` → `Command`, `multiple_occurrences` → `ArgAction::Count`, `value_of` → `get_one`, etc.).
- **flirt library slimmed**: `clap`/`fern`/`chrono`/`better-panic` were plain `[dependencies]` of lancelot-flirt but only used by its `src/bin/` tools. They're now optional behind a `cli` feature with `required-features` on the three binaries, so library consumers — including the wasm build via core — no longer pull them in (`cargo tree -p lancelot` no longer shows clap/fern/better-panic). `fern`/`chrono` remain as dev-dependencies for the test-only logging helper. Note the behavior change: building sig2pat/parsepat/decompress_sig now needs `cargo build -p lancelot-flirt --features cli`.
- **CLI dedup**: the ~50 lines of copy-pasted `--verbose`/`--quiet`/fern/`--config` plumbing in all four `bin/` tools now live in `lancelot_bin::cli` (`add_common_args`, `configure_logging`, `add_config_arg`, `configuration_from_matches`). Two intentional normalizations: `jh`'s log lines gain timestamps like the other tools (it keeps suppressing `lancelot::workspace` warnings via an `ignored_targets` parameter), and `be2`'s clap command name is fixed from `lancelot` (copy-paste) to `be2`.
- **dropped unused `bin/` deps**: `hexyl` (referenced only in comments), `hex`, `thiserror`.

Testing — full suites plus by-hand exercise of every migrated CLI (real binaries, no mocks):
- `cargo test`: lancelot 123 passed, lancelot-flirt 26+2 passed, lancelot-bin (jh) 5 passed; `pylancelot`/`python-flirt`/`jslancelot` all `cargo check` clean
- `lancelot functions` / `lancelot -vv` (verbosity counting), `be2` (147KB BinExport2 to stdout), `match_flirt` against the bundled msvc sigs (finds `_exit`, `__amsg_exit`), `jh` (JSONL output), `sig2pat --features cli` — all verified working after the clap 4 migration
- `cargo +nightly fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2

---
_Generated by [Claude Code](https://claude.ai/code/session_012g5ZfsvgVFxwBjts5MY2P2)_